### PR TITLE
add yaml deployment implementation for the crane-scheduler module

### DIFF
--- a/deploy/scheduler/deployment.yaml
+++ b/deploy/scheduler/deployment.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crane-scheduler
+  namespace: crane-system
+  labels:
+    component: scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: scheduler
+  template:
+    metadata:
+      labels:
+        component: scheduler
+    spec:
+      volumes:
+        - name: scheduler-config
+          configMap:
+            name: scheduler-config
+            defaultMode: 420
+        - name: dynamic-scheduler-policy
+          configMap:
+            name: dynamic-scheduler-policy
+            defaultMode: 420
+      containers:
+        - name: crane-scheduler
+          image: docker.io/gocrane/crane-scheduler:0.0.23
+          command:
+            - /scheduler
+            - --leader-elect=true
+            - --config=/etc/kubernetes/kube-scheduler/scheduler-config.yaml
+          resources:
+            requests:
+              cpu: 200m
+          volumeMounts:
+            - name: scheduler-config
+              readOnly: true
+              mountPath: /etc/kubernetes/kube-scheduler
+            - name: dynamic-scheduler-policy
+              readOnly: true
+              mountPath: /etc/kubernetes
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10259
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 10259
+              scheme: HTTPS
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: false
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      serviceAccountName: scheduler
+      serviceAccount: scheduler
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scheduler-config
+  namespace: crane-system
+data:
+  scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: true
+    profiles:
+    - schedulerName: default-scheduler
+      plugins:
+        filter:
+          enabled:
+          - name: Dynamic
+        score:
+          enabled:
+          - name: Dynamic
+            weight: 3
+      pluginConfig:
+      - name: Dynamic
+        args:
+          policyConfigPath: /etc/kubernetes/policy.yaml

--- a/deploy/scheduler/rbac.yaml
+++ b/deploy/scheduler/rbac.yaml
@@ -1,0 +1,169 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scheduler
+  namespace: crane-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scheduler
+subjects:
+  - kind: ServiceAccount
+    name: scheduler
+    namespace: crane-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scheduler
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scheduler
+rules:
+  - verbs:
+      - create
+      - patch
+      - update
+    apiGroups:
+      - ''
+      - events.k8s.io
+    resources:
+      - events
+  - verbs:
+      - create
+    apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+  - verbs:
+      - get
+      - update
+    apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - kube-scheduler
+  - verbs:
+      - create
+    apiGroups:
+      - ''
+    resources:
+      - endpoints
+  - verbs:
+      - get
+      - update
+    apiGroups:
+      - ''
+    resources:
+      - endpoints
+    resourceNames:
+      - kube-scheduler
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - nodes
+  - verbs:
+      - delete
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - pods
+  - verbs:
+      - create
+    apiGroups:
+      - ''
+    resources:
+      - bindings
+      - pods/binding
+  - verbs:
+      - patch
+      - update
+    apiGroups:
+      - ''
+    resources:
+      - pods/status
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - replicationcontrollers
+      - services
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - apps
+      - extensions
+    resources:
+      - replicasets
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - apps
+    resources:
+      - statefulsets
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+      - persistentvolumes
+  - verbs:
+      - create
+    apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+  - verbs:
+      - create
+    apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - storage.k8s.io
+    resources:
+      - '*'
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - namespaces


### PR DESCRIPTION
There are two services in the module, namely "crane- Scheduler-Controller "and "crane-scheduler", but only yaml deployment of the "crane-scheduler-controller" module is included in the code. This submission complements the  yaml deployment of crane-scheduler 