### PR TITLE
cleanup useless null pointer checks for nodeInfo.Node()

### DIFF
--- a/pkg/plugins/dynamic/plugins.go
+++ b/pkg/plugins/dynamic/plugins.go
@@ -42,11 +42,6 @@ func (ds *DynamicScheduler) Filter(ctx context.Context, state *framework.CycleSt
 		return framework.NewStatus(framework.Success, "")
 	}
 
-	node := nodeInfo.Node()
-	if node == nil {
-		return framework.NewStatus(framework.Error, "node not found")
-	}
-
 	nodeAnnotations, nodeName := nodeInfo.Node().Annotations, nodeInfo.Node().Name
 	if nodeAnnotations == nil {
 		nodeAnnotations = map[string]string{}
@@ -77,9 +72,6 @@ func (ds *DynamicScheduler) Score(ctx context.Context, state *framework.CycleSta
 	}
 
 	node := nodeInfo.Node()
-	if node == nil {
-		return 0, framework.NewStatus(framework.Error, "node not found")
-	}
 
 	nodeAnnotations := node.Annotations
 	if nodeAnnotations == nil {
@@ -90,7 +82,7 @@ func (ds *DynamicScheduler) Score(ctx context.Context, state *framework.CycleSta
 
 	score = score - int(hotValue*10)
 
-	finalScore := utils.NormalizeScore(int64(score),framework.MaxNodeScore,framework.MinNodeScore)
+	finalScore := utils.NormalizeScore(int64(score), framework.MaxNodeScore, framework.MinNodeScore)
 
 	klog.V(4).Infof("[crane] Node[%s]'s final score is %d, while score is %d and hot value is %f", node.Name, finalScore, score, hotValue)
 

--- a/pkg/plugins/noderesourcetopology/filter.go
+++ b/pkg/plugins/noderesourcetopology/filter.go
@@ -53,10 +53,6 @@ func (tm *TopologyMatch) Filter(
 		return framework.AsStatus(err)
 	}
 
-	if nodeInfo.Node() == nil {
-		return framework.NewStatus(framework.Error, "node(s) not found")
-	}
-
 	if utils.IsDaemonsetPod(pod) || len(s.targetContainerIndices) == 0 {
 		return nil
 	}


### PR DESCRIPTION
nodeInfo.Node() will never be nil, thus removing those validations.

For k/k, Null pointer check about nodeInfo.Node() from snapshot is removed for in-tree plugins, pls see following PR.

https://github.com/kubernetes/kubernetes/pull/117834