### PR TITLE
feat(annotator): add Prometheus basic auth and bearer token authentication

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -65,6 +65,10 @@ func (o *Options) Flags(flag *pflag.FlagSet) error {
 
 	flag.StringVar(&o.PolicyConfigPath, "policy-config-path", o.PolicyConfigPath, "Path to annotator policy config")
 	flag.StringVar(&o.PrometheusAddr, "prometheus-address", o.PrometheusAddr, "The address of prometheus, from which we can pull metrics data.")
+	flag.StringVar(&o.PrometheusUser, "prometheus-user", o.PrometheusUser, "The username of prometheus.")
+	flag.StringVar(&o.PrometheusPassword, "prometheus-password", o.PrometheusPassword, "The password of prometheus.")
+	flag.StringVar(&o.PrometheusBearer, "prometheus-bearer", "Bearer", "The custom bearer auth header of prometheus.")
+	flag.StringVar(&o.PrometheusBearerToken, "prometheus-bearer-token", o.PrometheusBearerToken, "The bearer auth token of prometheus.")
 	flag.Int32Var(&o.BindingHeapSize, "binding-heap-size", o.BindingHeapSize, "Max size of binding heap size, used to store hot value data.")
 	flag.Int32Var(&o.ConcurrentSyncs, "concurrent-syncs", o.ConcurrentSyncs, "The number of annotator controller workers that are allowed to sync concurrently.")
 	flag.StringVar(&o.kubeconfig, "kubeconfig", o.kubeconfig, "Path to kubeconfig file with authorization information")
@@ -123,7 +127,7 @@ func (o *Options) Config() (*controllerappconfig.Config, error) {
 
 	c.LeaderElectionClient = clientset.NewForConfigOrDie(rest.AddUserAgent(kubeconfig, "leader-election"))
 
-	c.PromClient, err = prometheus.NewPromClient(o.PrometheusAddr)
+	c.PromClient, err = prometheus.NewPromClient(&o.PrometheusConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
@@ -88,6 +89,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/onsi/gomega v1.18.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runc v1.0.2 // indirect

--- a/pkg/controller/annotator/config/types.go
+++ b/pkg/controller/annotator/config/types.go
@@ -2,6 +2,7 @@ package config
 
 // AnnotatorConfiguration holds configuration for a node annotator.
 type AnnotatorConfiguration struct {
+	PrometheusConfig
 	// BindingHeapSize limits the size of Binding Heap, which stores the lastest
 	// pod scheduled imformation.
 	BindingHeapSize int32
@@ -9,6 +10,18 @@ type AnnotatorConfiguration struct {
 	ConcurrentSyncs int32
 	// PolicyConfigPath specified the path of Scheduler Policy File.
 	PolicyConfigPath string
+}
+
+// PrometheusConfig holds configuration for a prometheus client.
+type PrometheusConfig struct {
 	// PrometheusAddr is the address of Prometheus Service.
 	PrometheusAddr string
+	// PrometheusUser is the basic auth username of Prometheus Service.
+	PrometheusUser string
+	// PrometheusPassword is the basic auth password of Prometheus Service.
+	PrometheusPassword string
+	// PrometheusBearer is the custom bearer auth header of Prometheus Service.
+	PrometheusBearer string
+	// PrometheusBearerToken is the bearer auth token of Prometheus Service.
+	PrometheusBearerToken string
 }


### PR DESCRIPTION
Our Prometheus requires certification, so added support for Prometheus basic auth and bearer token authentication.